### PR TITLE
Changes to prevent #2 Key Error

### DIFF
--- a/boltdb/page.py
+++ b/boltdb/page.py
@@ -98,8 +98,8 @@ class Page:
     def write_ids(self, ids):
         self.flags = freelistPageFlag
         self.count = len(ids)
-        for i in ids:
-            self.data[i*8:(i+1)*8] = i.to_bytes(8, "little")
+        for i, id in enumerate(ids):
+            self.data[i*8:(i+1)*8] = id.to_bytes(8, "little")
         self.write_header()
 
 


### PR DESCRIPTION
While writing ids to the file, we should add them to the correct index positions.
- "free_ids()" method reads from the positions [index*8, (index+1)*8] and not from [id*8, (id+1)*8].
- "write_ids()" should also write to the same.